### PR TITLE
Close off heroku defaults

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,12 +13,12 @@
       },
       "CORSANYWHERE_ALLOWLIST": {
         "description": "Allow-list of domains; comma-separated.",
-        "value": "",
+        "value": "http://localhost",
         "required": false
       },
       "CORSANYWHERE_RATELIMIT": {
         "description": "If you run an open proxy, you will be violating Heroku terms. Rate-limiting can help mitigate this.",
-        "value": "",
+        "value": "1 1",
         "required": false
       },
       "NODE_ENV": "production",


### PR DESCRIPTION
It was pointed out that by default this leaves an open proxy. To be fair to heroku, this isn't cool. Not only have I closed off the deploy and rate-limited to 1 request per minute from localhost (server side, so cookie clearing won't work); I've also updated those to be defaults.

See https://github.com/Rob--W/cors-anywhere/issues/320 (I will not be dialing back on the inclusive language)